### PR TITLE
commented out window.location.hash="";

### DIFF
--- a/jquery.app-folders.js
+++ b/jquery.app-folders.js
@@ -123,7 +123,7 @@
 					// Set the URL Title to match the opened folder.
 					// Pushstate only works in modern browsers, but it works with browser history as well.
 					// This is optional and removes the trailing hash (#) from the URL.
-					window.location.hash="";
+//					window.location.hash="";
 					if (settings.URLrewrite != false) {
 						window.history.pushState("object or string","Title" , settings.URLbase);
 					}


### PR DESCRIPTION
I'm no expect at jQuery (total n00b in fact), but it would seem that the issue described here: https://github.com/spsaucier/App-Folders/issues/3 is being caused by the `window.location.hash="";` line.

Upon removing it, the script stopped jumping back to the top.
